### PR TITLE
chore: add affected-script aliases for shared lint workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,11 @@
     "scripts": {
         "audit": "audit-ci --config ./audit-ci.jsonc",
         "build": "packem build --development",
+        "build:affected:packages": "pnpm run build",
         "build:prod": "packem build --production",
+        "lint:affected:eslint": "pnpm run lint:eslint",
+        "lint:affected:package-json": "pnpm run lint:package-json",
+        "lint:affected:types": "pnpm run lint:types",
         "lint:eslint": "eslint . --max-warnings=0",
         "lint:eslint:fix": "pnpm run lint:eslint --fix",
         "lint:package-json": "publint",


### PR DESCRIPTION
## Summary

The shared `anolilab/workflows/.github/workflows/lint.yml` runs:
- `pnpm run build:affected:packages`
- `pnpm run lint:affected:eslint`
- `pnpm run lint:affected:package-json`
- `pnpm run lint:affected:types`

In NX monorepos these run only on changed projects. This repo is a single package, so the aliases just forward to the existing single-package commands.

Fixes `ERR_PNPM_NO_SCRIPT Missing script: build:affected:packages` (and the matching eslint/types/package-json failures) seen on every PR's `lint / Lint (eslint, types, attw)` check.

## Test plan
- [ ] `lint / Lint (eslint, types, attw)` passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new build and linting scripts to the development tooling configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anolilab/unplugin-favicons/pull/207?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->