### PR TITLE
ci: bump semantic-release build job node-version to 20.x

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -51,7 +51,7 @@ jobs:
               id: "setup"
               uses: "anolilab/workflows/step/setup@main"
               with:
-                  node-version: "18.x"
+                  node-version: "20.x"
                   cache-prefix: "semantic-release"
 
             - name: "Build Production"


### PR DESCRIPTION
## Summary
- The `build` job in `semantic-release.yml` pinned Node **18.x**, but pnpm 10's `@pnpm/exe` self-installer requires Node 20+ and crashes on 18 (`ERR_INVALID_ARG_TYPE` in `setup.js`), failing the Semantic Release pipeline at the "Setup resources and environment" step.
- Bumps it to **20.x**, matching the sibling `semantic-release` job (already 20.x) and the rest of CI (test: 20/22/24, lint: 22, preview-release: 20.x).
- This was the only remaining red pipeline on `main` after the build-OOM fix (#210) and the dependency-security merges.

## Note
Unblocking this re-enables the release flow: once merged, semantic-release will run on `main` and may publish a new npm version + GitHub release for the accumulated commits. This is intended.

## Test plan
- [ ] Semantic Release "Build Package" job gets past the setup step on Node 20
- [ ] `build:prod` + `test:coverage` succeed
- [ ] semantic-release publishes (or correctly no-ops) on merge to main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version in build environment to 20.x.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/anolilab/unplugin-favicons/pull/211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->