### PR TITLE
ci: disable npm signatures audit in semantic-release pipeline

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -53,6 +53,7 @@ jobs:
               with:
                   node-version: "20.x"
                   cache-prefix: "semantic-release"
+                  run-signatures-audit: "false" # npm audit signatures mis-resolves rolldown-vite as an optional peer of vite@8; pnpm installs it correctly
 
             - name: "Build Production"
               run: "pnpm run build:prod"
@@ -104,6 +105,7 @@ jobs:
               with:
                   node-version: "20.x"
                   cache-prefix: "semantic-release"
+                  run-signatures-audit: "false" # npm audit signatures mis-resolves rolldown-vite as an optional peer of vite@8; pnpm installs it correctly
 
             - name: "Download Build Artifacts"
               uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1


### PR DESCRIPTION
## Summary
- The Node 18→20 fix (#211) let the Semantic Release build job get past the pnpm self-installer, but it now fails on `npm audit signatures`, which cannot resolve `rolldown-vite@8.0.14`.
- `rolldown-vite` is an optional peer of the `vite@8` ecosystem (used by vitest 4). `rolldown-vite` has no published 8.x release (latest is 7.3.1), while the project legitimately uses real `vite@8.0.14`. pnpm correctly skips the unmet optional peer; `npm audit signatures` does not and errors with `ETARGET`.
- `pnpm install`, `pnpm audit`, and the full test matrix all pass on this commit. The only failure is this npm-side gate.
- Fix: set `run-signatures-audit: false` on both setup steps in `semantic-release.yml`, mirroring the Preview Release workflow which already disables it. The pnpm vulnerability audit (`run-npm-audit`) stays enabled.

## Test plan
- [ ] Merge and confirm the Semantic Release build job passes the setup step on Node 20.
- [ ] Confirm `build:prod` and `test:coverage` succeed and semantic-release publishes or correctly no-ops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)