### PR TITLE
ci: bump semantic-release pipeline node-version to 22.x

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -51,7 +51,7 @@ jobs:
               id: "setup"
               uses: "anolilab/workflows/step/setup@main"
               with:
-                  node-version: "20.x"
+                  node-version: "22.x"
                   cache-prefix: "semantic-release"
                   run-signatures-audit: "false" # npm audit signatures mis-resolves rolldown-vite as an optional peer of vite@8; pnpm installs it correctly
 
@@ -103,7 +103,7 @@ jobs:
               id: "setup"
               uses: "anolilab/workflows/step/setup@main"
               with:
-                  node-version: "20.x"
+                  node-version: "22.x"
                   cache-prefix: "semantic-release"
                   run-signatures-audit: "false" # npm audit signatures mis-resolves rolldown-vite as an optional peer of vite@8; pnpm installs it correctly
 


### PR DESCRIPTION
## Summary
- Follow-up to #211/#212. With the signatures audit disabled, the Semantic Release build job now passes fully on Node 20 (build:prod + test:coverage green), but the `pnpm exec semantic-release` step fails: `semantic-release@25` requires Node `^22.14.0 || >=24.10.0` and found `v20.20.2`.
- Bump both setup steps in `semantic-release.yml` from `20.x` to `22.x`. The test matrix already validates `node-22`.

## Test plan
- [ ] Merge and confirm the Semantic Release run on main completes: build job green and `pnpm exec semantic-release` runs (publishes a release/tag or correctly determines no release is due).

🤖 Generated with [Claude Code](https://claude.com/claude-code)